### PR TITLE
fixed 500 error when `hd` field missing on JWT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - added honeycomb instrumentation
 ### Changed
+- fixed 500 error with missing `hd` field on JWT when accesssed via
+  API Gateway.
 ### Removed
 
 ## [v0.1.4] - 2021-11-29

--- a/src/iapauth/middleware.py
+++ b/src/iapauth/middleware.py
@@ -63,7 +63,7 @@ class JWTAuthenticator(object):
                 algorithms=["ES256"],
                 audience=audience,
             )
-            return (True, info["email"], info["hd"])
+            return (True, info["email"], info.get("hd"))
         except jose.exceptions.JOSEError as e:
             # log it
             print("bad JWT: {}".format(e))


### PR DESCRIPTION
When accessing through the API Gateway, the JWT payload contains different fields than when accessing directly through the IAP.

Eg, a normal direct access has a payload like:

```
{
  "aud": "/projects/466589242038/apps/anders-klanten-dev",
  "azp": "/projects/466589242038/apps/anders-klanten-dev",
  "email": "anders@noderabbit.com",
  "exp": 1638350499,
  "hd": "noderabbit.com",
  "iat": 1638349899,
  "iss": "https://cloud.google.com/iap",
  "sub": "accounts.google.com:108121296498532996032"
}
```

And we use the `email` field to determine which user it is and the `hd` field to potentially grant them admin/superuser access.

When accessing via API Gateway, the gateway's service account apparently does things a bit different and the payload looks more like:

```
{
  "aud": "/projects/466589242038/apps/anders-klanten-dev",
  "azp": "/projects/466589242038/apps/anders-klanten-dev",
  "email": "apigateway-3621-testing@appsembler-testing.iam.gserviceaccount.com",
  "exp": 1638291196,
  "iat": 1638290596,
  "iss": "https://cloud.google.com/iap",
  "sub": "accounts.google.com:109967078724472699637"
}
```

We still have an `email`, but there's no `hd`.

So we need to not crash when that happens. Luckily, we typically don't want to grant the API Gateway service account elevated permissions, so it's fine to just let the domain default to `None`.

An open question we can address later is whether there's any reasonable situation where we want to allow the payload to not have the `email` field and whether JWT/IAP even allows that. Currently, that would cause a similar exception, but I'm OK with that until we've thought through what the safe alternative is if `email` is missing.